### PR TITLE
fix: rename INGESTION_API_KEY to DIODE_API_KEY

### DIFF
--- a/docs/netbox-extensions/diode-client.md
+++ b/docs/netbox-extensions/diode-client.md
@@ -27,7 +27,7 @@ pip install netboxlabs-diode-sdk
 
 ### Configure the client
 
-Set the following environment variable with the `INGESTION_API_KEY` API key from the plugin installation:
+Set the following environment variable with the `DIODE_API_KEY` API key from the plugin installation:
 
 ```bash
 export DIODE_API_KEY=<API key from Diode plugin installation>

--- a/docs/netbox-extensions/diode-plugin.md
+++ b/docs/netbox-extensions/diode-plugin.md
@@ -42,7 +42,7 @@ export DIODE_TO_NETBOX_API_KEY=$(head -c20 </dev/urandom|xxd -p); env | grep DIO
 # API key for the NetBox service to interact with Diode
 export NETBOX_TO_DIODE_API_KEY=$(head -c20 </dev/urandom|xxd -p); env | grep NETBOX_TO_DIODE_API_KEY
 # API key for Diode SDKs to ingest data into Diode
-export INGESTION_API_KEY=$(head -c20 </dev/urandom|xxd -p); env | grep INGESTION_API_KEY
+export DIODE_API_KEY=$(head -c20 </dev/urandom|xxd -p); env | grep DIODE_API_KEY
 ```
 
 !!! warning
@@ -62,7 +62,7 @@ The plugin is successfully installed and configured:
 
 - The NetBox Labs DIODE plugin is visible in the right-hand navigation bar
 - Three NetBox users and three corresponding API keys have been created:
-    - `INGESTION`
+    - `DIODE`
     - `DIODE_TO_NETBOX`
     - `NETBOX_TO_DIODE`
 

--- a/docs/netbox-extensions/diode-server.md
+++ b/docs/netbox-extensions/diode-server.md
@@ -27,7 +27,7 @@ Edit the `.env` to match the environment:
 
 * `NETBOX_DIODE_PLUGIN_API_BASE_URL`: URL for NetBox, appended with `/api/plugins/diode`
 * `DIODE_TO_NETBOX_API_KEY`: API key from Diode plugin installation
-* `INGESTION_API_KEY`: API key from Diode plugin installation
+* `DIODE_API_KEY`: API key from Diode plugin installation
 * `NETBOX_TO_DIODE_API_KEY`: API key from Diode plugin installation
 
 ### Run the Diode server


### PR DESCRIPTION
Reflect changes introduced in:
* https://github.com/netboxlabs/diode-netbox-plugin/releases/tag/v0.2.0
* https://github.com/netboxlabs/diode/releases/tag/diode-reconciler%2Fv0.3.0
* https://github.com/netboxlabs/diode/releases/tag/diode-ingester%2Fv0.3.0