### PR TITLE
ENG-3414: document postgresql backups

### DIFF
--- a/docs/netbox-enterprise/nbe-backups.md
+++ b/docs/netbox-enterprise/nbe-backups.md
@@ -1,4 +1,4 @@
-# NetBox Enterprise Data
+# NetBox Enterprise Backups
 
 Much like the NetBox software itself, NetBox Enterprise uses 2 main datastores: PostgreSQL, and Redis.
 
@@ -14,7 +14,9 @@ For each type of datastore you can choose to use a built-in deployment, or confi
 
 ### External Datastores
 
-If you are providing your own database(s) for use by NetBox Enterprise, it is expected that you have your own processes for high availability, backup, and restore.
+!!! warning
+
+  If you are providing your own database(s) for use by NetBox Enterprise, it is expected that you have your own processes for high availability, backup, and restore.
 
 ### Built-In PostgreSQL
 

--- a/docs/netbox-enterprise/nbe-data.md
+++ b/docs/netbox-enterprise/nbe-data.md
@@ -1,0 +1,40 @@
+# NetBox Enterprise Data
+
+Much like the NetBox software itself, NetBox Enterprise uses 2 main datastores: PostgreSQL, and Redis.
+
+PostgreSQL is used for the primary model data in NetBox, including sites, facilities, racks, and so on.
+Redis is used for caching, the task queue, and some other data including stored scripts and such.
+
+Additionally, NetBox Enterprise uses an S3-compatible store for some specific resources, most notably image uploads.
+_NOTE: The built-in S3-compatible store keeps its data in Redis, so it is not necessary to back it up separately._
+
+For each type of datastore you can choose to use a built-in deployment, or configure NetBox Enterprise to use an existing external resource already in your environment.
+
+## Backing Up Your Data
+
+### External Datastores
+
+If you are providing your own database(s) for use by NetBox Enterprise, it is expected that you have your own processes for high availability, backup, and restore.
+
+### Built-In PostgreSQL
+
+The built-in PostgreSQL is deployed using the CrunchyData Postgres Operator.
+
+Since the PostgreSQL CLI tools are already available inside the cluster, all we need to do to dump the database is to call into the correct container and run a `pg_dump` there.
+
+_NOTE: The default namespace for installs is `netbox-enterprise`, but if you have overridden it for your install, replace the argument after `-n` with the proper namespace for your instance._
+
+```shell
+POSTGRESQL_MAIN_POD="$(kubectl get pod -o name -n netbox-enterprise -l 'postgres-operator.crunchydata.com/role=master')"
+kubectl exec "${POSTGRESQL_MAIN_POD}" -n netbox-enterprise -c database -- \
+    pg_dump -Fc -C netbox > netbox.pgsql
+```
+
+This will create a `netbox.pgsql` file in your local directory.
+Save it somewhere safe for future restores.
+
+_This command uses the `-Fc` argument to `pg_dump`, which instructs it to create a "custom" format dump file.
+This is a binary file that is more efficient than a standard SQL dump, and also provides some additional metadata that makes PostgreSQL handle restores across different versions a bit better.
+You can remove the `-Fc` if you wish to create a readable text file dump instead._
+
+For more details on backing up NetBox databases, see [the official NetBox documentation](https://netboxlabs.com/docs/netbox/en/stable/administration/replicating-netbox/).

--- a/docs/netbox-enterprise/nbe-data.md
+++ b/docs/netbox-enterprise/nbe-data.md
@@ -3,7 +3,7 @@
 Much like the NetBox software itself, NetBox Enterprise uses 2 main datastores: PostgreSQL, and Redis.
 
 PostgreSQL is used for the primary model data in NetBox, including sites, facilities, racks, and so on.
-Redis is used for caching, the task queue, and some other data including stored scripts and such.
+Redis is used for caching, the task queue, and some other data including stored scripts.
 
 Additionally, NetBox Enterprise uses an S3-compatible store for some specific resources, most notably image uploads.
 _NOTE: The built-in S3-compatible store keeps its data in Redis, so it is not necessary to back it up separately._

--- a/docs/netbox-enterprise/nbe-data.md
+++ b/docs/netbox-enterprise/nbe-data.md
@@ -38,6 +38,8 @@ If you are running the Embedded Cluster, you will need to first execute a comman
 
 #### All Installs
 
+To perform a database dump, run these commands:
+
 ```shell
 POSTGRESQL_MAIN_POD="$(kubectl get pod -o name -n netbox-enterprise -l 'postgres-operator.crunchydata.com/role=master')"
 kubectl exec "${POSTGRESQL_MAIN_POD}" -n netbox-enterprise -c database -- \

--- a/docs/netbox-enterprise/nbe-data.md
+++ b/docs/netbox-enterprise/nbe-data.md
@@ -22,7 +22,7 @@ The built-in PostgreSQL is deployed using the CrunchyData Postgres Operator.
 
 Since the PostgreSQL CLI tools are already available inside the cluster, all we need to do to dump the database is to call into the correct container and run a `pg_dump` there.
 
-_NOTE: The default namespace for installs is `netbox-enterprise`, but if you have overridden it for your install, replace the argument after `-n` with the proper namespace for your instance._
+_NOTE: The default namespace for installs is `netbox-enterprise`, but if you have overridden it, replace the argument after `-n` with the proper namespace for your instance in the commands below._
 
 #### KOTS Install
 

--- a/docs/netbox-enterprise/nbe-data.md
+++ b/docs/netbox-enterprise/nbe-data.md
@@ -24,6 +24,20 @@ Since the PostgreSQL CLI tools are already available inside the cluster, all we 
 
 _NOTE: The default namespace for installs is `netbox-enterprise`, but if you have overridden it for your install, replace the argument after `-n` with the proper namespace for your instance._
 
+#### KOTS Install
+
+If you are running your own cluster, and have installed using KOTS, make sure you have `kubectl` in your `PATH` and that it is able to access your cluster.
+
+#### Embedded Cluster
+
+If you are running the Embedded Cluster, you will need to first execute a command to get a debug shell that knows how to speak to the cluster.  To do this, run:
+
+```shell
+/var/lib/embedded-cluster/bin/netbox-enterprise shell
+```
+
+#### All Installs
+
 ```shell
 POSTGRESQL_MAIN_POD="$(kubectl get pod -o name -n netbox-enterprise -l 'postgres-operator.crunchydata.com/role=master')"
 kubectl exec "${POSTGRESQL_MAIN_POD}" -n netbox-enterprise -c database -- \

--- a/docs/netbox-enterprise/nbe-troubleshooting.md
+++ b/docs/netbox-enterprise/nbe-troubleshooting.md
@@ -1,0 +1,20 @@
+# Troubleshooting Tips and Tricks
+
+NetBox Enterprise is designed to harness the power of Kubernetes while minimizing the amount of work the average person needs to manage it.
+However, sometimes it's still useful or necessary to peek under the hood.
+
+## Applications
+
+The following applications are used for various facets of administration:
+
+* [kubectl](https://kubernetes.io/docs/tasks/tools/)\*: CLI for interacting with clusters.
+* [preflight](https://troubleshoot.sh/)\*: CLI for manually running preflight validation checks.
+  Install by running:<br>
+  `curl https://krew.sh/preflight | bash`
+* [support-bundle](https://troubleshoot.sh/)\*: CLI for manually generating support bundles.
+  Install by running:<br>
+  `curl https://krew.sh/support-bundle | bash`
+* [k9s](https://k9scli.io/): a TUI for managing and viewing cluster resources.
+
+_\* provided by the Embedded Cluster install_
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -103,4 +103,4 @@ extra:
   analytics:
     provider: google
     property: G-Q107GMDTJM
-copyright: Copyright &copy; 2023 NetBox Labs
+copyright: Copyright &copy; 2024 NetBox Labs

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -78,6 +78,9 @@ nav:
     - KOTS:
       - Requirements: "netbox-enterprise/nbe-kots-requirements.md"
       - Installation: "netbox-enterprise/nbe-kots-installation.md"
+    - Administration:
+      - Data: "netbox-enterprise/nbe-data.md"
+      - Troubleshooting: "netbox-enterprise/nbe-troubleshooting.md"
   - Integrations: 
     - NetBox Ansible Collection: "netbox-integrations/netbox-ansible-collection.md"
     - pyATS: "netbox-integrations/pyats.md"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -79,7 +79,7 @@ nav:
       - Requirements: "netbox-enterprise/nbe-kots-requirements.md"
       - Installation: "netbox-enterprise/nbe-kots-installation.md"
     - Administration:
-      - Data: "netbox-enterprise/nbe-data.md"
+      - Backups: "netbox-enterprise/nbe-backups.md"
       - Troubleshooting: "netbox-enterprise/nbe-troubleshooting.md"
   - Integrations: 
     - NetBox Ansible Collection: "netbox-integrations/netbox-ansible-collection.md"


### PR DESCRIPTION
This PR does a couple of things:

1. add an "Administration" section to the NBE docs
2. create a "Troubleshooting" page that lists some useful and/or required tools for doing various troubleshooting
3. adds documentation on dumping the data from PostgreSQL
4. fixes the copyright date to 2024