### PR TITLE
ENG-4158: doc refactor and updates

### DIFF
--- a/docs/netbox-enterprise/nbe-backups.md
+++ b/docs/netbox-enterprise/nbe-backups.md
@@ -54,7 +54,7 @@ This feature is included in Embedded Cluster installs, and can be enabled by ins
 Besides disaster recovery, it is also a good idea to keep backups of your data in case you want to view, partially restore, or move your data to another system.
 
 !!! info "NetBox Enterprise Namespace"
-    The default namespace for the Embedded Cluster dis `kotsadm`.
+    The default namespace for the Embedded Cluster is `kotsadm`.
 
     The instructions below default to `kotsadm`, but you can change the `NETBOX_NAMESPACE` export to match your system.
 

--- a/docs/netbox-enterprise/nbe-ec-installation.md
+++ b/docs/netbox-enterprise/nbe-ec-installation.md
@@ -1,11 +1,8 @@
 # NetBox Enterprise Embedded Cluster Installation
 
-## Conventional Installation
-
 You should be able to follow these instructions for installing the Embedded Cluster in most environments.
-If you are in a more restrictive environment, see the [Advanced Installation](#advanced-installation) section below.
 
-### Deploying the cluster
+## Deploying the cluster
 
 The following steps are required for an Embedded Cluster (EC) installation of NetBox Enterprise.
 
@@ -27,7 +24,7 @@ The following steps are required for an Embedded Cluster (EC) installation of Ne
    Visit the Admin Console to configure and install netbox-enterprise: http://my.netbox-enterprise.host:30000
    ```
 
-### Deploying NetBox
+## Deploying NetBox
 
 Access the NetBox Enterprise admin console and configure NetBox.
 
@@ -57,7 +54,7 @@ Finally, accept the terms of service by writing "ACCEPT" (case-insensitive) and 
 
 ![Accept TOS](../images/netbox-enterprise/netbox-enterprise-accept-tos.png)
 
-### Finish the Deployment
+## Finish the Deployment
 
 Once you have accepted the terms of service and continued on to the main admin console, deployment will start.
 The first deployment will take some time, as it brings up all subsystems and runs migrations to initialize the database.
@@ -68,123 +65,9 @@ The `Unavailable` status will change to `Ready` once the deployment is complete 
 
 ![Deployment Ready](../images/netbox-enterprise/netbox-enterprise-ready.png)
 
-### Verify the Deployment
+## Verify the Deployment
 
 Once you see `Ready`, NetBox Enterprise is fully deployed, and available on ports `80` and `443`.
 
 - ![NetBox Enterprise Login](../images/netbox-enterprise/netbox-enterprise-login.png)
 - ![NetBox Enterprise Home](../images/netbox-enterprise/netbox-enterprise-app-home.png)
-
-## Advanced Installation
-
-### Proxies
-
-If you are installing in a restrictive environment, you may have to provide extra configuration at install-time.
-NetBox Enterprise as of version 1.6.0 has support for installing through proxies using the following configuration.
-
-#### Proxy Configuration
-
-Before you can install, you _must_ configure your proxy to allow the following hostnames:
-
-* **app.enterprise.netboxlabs.com**
-* **get.enterprise.netboxlabs.com**
-* **proxy.enterprise.netboxlabs.com**
-* **registry.enterprise.netboxlabs.com**
-
-They are required to access various parts of the Enmbedded Cluster and NetBox Enterprise installation resources.
-
-Additionally, you _may_ also want to configure a few more hosts:
-
-* **api.netbox.oss.netboxlabs.com** - used to query an API for information on NetBox plugins
-* **census.netbox.oss.netboxlabs.com** - used to collect anonymized data about your NetBox version. For details, see [the NetBox documentation](https://netboxlabs.com/docs/netbox/en/stable/configuration/miscellaneous/#census_reporting_enabled).
-
-#### Installation
-
-Once you have configured your proxy to allow access to the NetBox Enterprise hosts, you will need to pass some additional arguments to the Embedded Cluster installer.
-Note that the Embedded Cluster will _not_ inherit proxy settings from the shell environment.
-
-* `--http-proxy <proxy-url>`
-  
-  The proxy url should be a complete URL to reach the proxy. (eg, `http://myhost:8888`)
-* `--https-proxy <proxy-url>`
-
-  Like `--http-proxy`, this should be the proxy's URL.
-* `--no-proxy`
-
-  By default, the Embedded Cluster will automatically disable proxying on the internal cluster addresses, as well as the default network interface on your host.
-  
-  In some cases, if it can't autodetect an interface or you have a more complicated network, you may need to specify this manually in the form of a comma-separated list of addresses with CIDR netmasks (`1.2.3.4/32`), or domains (`foo.com`, `*.bar.com`).
-
-#### Man-In-The-Middle (MITM) Proxies
-
-If you are using a MITM proxy (ie, one which uses an internal TLS certificate authority for communication with the proxy, rather than directly passing encrypted traffic), you will need an additional option:
-
-* `--private-ca </path/to/private-ca-bundle>`
-
-This will allow the Embedded Cluster to accept traffic that has been encrypted using your internal CA.
-
-### Firewalld
-
-If you are using Firewalld (commonly found on RHEL installations, among others), you will need to create a zone for the cluster before installing.
-
-1. Determine any host IP addresses or networks (external or otherwise) that might need access to the cluster.
-2. Create a file called `/etc/firewalld/zones/embedded-cluster.xml` with the following contents:
-   ```xml
-   <?xml version="1.0" encoding="utf-8"?>
-   <zone target="ACCEPT">
-     <short>embedded-cluster</short>
-     <description>Zone for Embedded Cluster communication</description>
-     <!-- HOST IP ADDRESSES GO HERE -->
-     <source address="10.244.0.0/17"/>
-     <source address="10.244.128.0/17"/>
-     <port protocol="tcp" port="2380"/>
-     <port protocol="udp" port="4789"/>
-     <port protocol="tcp" port="6443"/>
-     <port protocol="tcp" port="7443"/>
-     <port protocol="tcp" port="9091"/>
-     <port protocol="tcp" port="9443"/>
-     <port protocol="tcp" port="10249"/>
-     <port protocol="tcp" port="10250"/>
-     <port protocol="tcp" port="10256"/>
-     <port protocol="tcp" port="30000"/>
-     <port protocol="tcp" port="22"/>
-   </zone>
-   ```
-3. In the spot where it says `<!-- HOST IP ADDRESSES GO HERE -->`, add a `<source />` tag for each host or network you want to allow.
-   For example, if your external IP is `1.2.3.4`, and you also have a private class C network `192.168.123.0`, you would add two lines:
-   ```xml
-   <source address="1.2.3.4/32" />
-   <source address="192.168.123.0/24" />
-   ```
-4. Run `sudo firewall-cmd --reload` to load the zone configuration.
-
-### SELinux
-
-There are two steps to installing with SELinux enabled with enforcement turned on.
-
-First, before you install the Embedded Cluster, run:
-```bash
-setenforce 0
-```
-
-...this will temporarily disable SELinux enforcement until you reenable it, or reboot.
-
-Next, follow the normal instructions for [Conventional Installation](#conventional-installation) above.
-
-Finally, run the following commands to make sure your Embedded Cluster installation is accessible with enforcement enabled:
-
-```bash
-export EC_DIR="/var/lib/embedded-cluster"
-export KUBE_DIR="${EC_DIR}/k0s"
-
-sudo semanage fcontext -a -t container_var_lib_t "${EC_DIR}"
-sudo restorecon -R -v "${EC_DIR}"
-
-sudo semanage fcontext -a -t container_runtime_exec_t "${KUBE_DIR}/bin/containerd.*"
-sudo semanage fcontext -a -t container_runtime_exec_t "${KUBE_DIR}/bin/runc"
-sudo restorecon -R -v "${KUBE_DIR}/bin"
-
-sudo semanage fcontext -a -t container_var_lib_t "${KUBE_DIR}/containerd(/.*)?"
-sudo semanage fcontext -a -t container_ro_file_t "${KUBE_DIR}/containerd/io.containerd.snapshotter.*/snapshots(/.*)?"
-sudo restorecon -R -v ${KUBE_DIR}/containerd
-```

--- a/docs/netbox-enterprise/nbe-ec-requirements.md
+++ b/docs/netbox-enterprise/nbe-ec-requirements.md
@@ -20,3 +20,121 @@ The following are the _recommended_ system requirements for a **production** dep
 ### Architecture
 
 - x86-64
+
+## Special Cases for Restricted Environments
+
+In some restricted environments, you will need to take additional steps alongside the [basic installation instructions](./nbe-ec-installation.md).
+
+### Traditional Proxies
+
+As of version 1.6.0, NetBox Enterprise supports installing through proxies using the following configuration.
+
+#### Proxy Configuration
+
+Before you can install, you _must_ configure your proxy to allow the following hostnames:
+
+* **app.enterprise.netboxlabs.com**
+* **get.enterprise.netboxlabs.com**
+* **proxy.enterprise.netboxlabs.com**
+* **registry.enterprise.netboxlabs.com**
+
+They are required to access various parts of the Embedded Cluster and NetBox Enterprise installation resources.
+
+#### Installation
+
+Once you have configured your proxy to allow access to the NetBox Enterprise hosts, you will need to pass some additional arguments to the Embedded Cluster installer when following the [basic installation instructions](./nbe-ec-installation.md).
+
+!!! note
+    The Embedded Cluster will _not_ inherit proxy settings from the shell environment, they must be explicitly provided on the installation command-line.
+
+* `--http-proxy <proxy-url>` and `--https-proxy <proxy-url>`
+
+    The proxy url should be a complete URL to reach the proxy. (eg, `http://myhost:8888`)
+
+* `--no-proxy`
+
+    By default, the Embedded Cluster will automatically disable proxying on the internal cluster addresses, as well as the default network interface on your host.
+
+    In some cases, if the installer can't autodetect an interface or if you have a more complicated network, you may need to specify this manually.
+    It should be in the form of a comma-separated list of addresses with CIDR netmasks (`1.2.3.4/32`), or domains (`foo.com`, `*.bar.com`).
+
+### Man-In-The-Middle (MITM) Proxies
+
+If you are using a MITM proxy (ie, one which uses an internal TLS certificate authority for communication with the proxy, rather than directly passing encrypted traffic), you will need an additional option:
+
+* `--private-ca </path/to/private-ca-bundle>`
+
+This will allow the Embedded Cluster to accept traffic that has been encrypted using your internal CA.
+
+### Firewalld
+
+If you are using Firewalld (commonly found on RHEL installations), you will need to create a zone for the cluster before installing.
+
+1. Determine any host IP addresses or networks (external or otherwise) that might need access to the cluster.
+2. Create a file called `/etc/firewalld/zones/embedded-cluster.xml` with the following contents:
+   ```xml
+   <?xml version="1.0" encoding="utf-8"?>
+   <zone target="ACCEPT">
+     <short>embedded-cluster</short>
+     <description>Zone for Embedded Cluster communication</description>
+     <!-- HOST IP ADDRESSES GO HERE -->
+     <source address="10.244.0.0/17"/>
+     <source address="10.244.128.0/17"/>
+     <port protocol="tcp" port="2380"/>
+     <port protocol="udp" port="4789"/>
+     <port protocol="tcp" port="6443"/>
+     <port protocol="tcp" port="7443"/>
+     <port protocol="tcp" port="9091"/>
+     <port protocol="tcp" port="9443"/>
+     <port protocol="tcp" port="10249"/>
+     <port protocol="tcp" port="10250"/>
+     <port protocol="tcp" port="10256"/>
+     <port protocol="tcp" port="30000"/>
+     <port protocol="tcp" port="22"/>
+   </zone>
+   ```
+3. In the spot where it says `<!-- HOST IP ADDRESSES GO HERE -->`, add a `<source />` tag for each host or network you want to allow.
+   For example, if your external IP is `1.2.3.4`, and you also have a private class C network `192.168.123.0`, you would add two lines:
+   ```xml
+   <source address="1.2.3.4/32" />
+   <source address="192.168.123.0/24" />
+   ```
+4. Run `sudo firewall-cmd --reload` to load the zone configuration.
+
+Then you can follow the [basic installation instructions](./nbe-ec-installation.md) as normal.
+
+### SELinux
+
+There are two steps to installing with SELinux enabled with enforcement turned on.
+
+First, before you install the Embedded Cluster, run:
+```bash
+sudo setenforce 0
+```
+
+This will temporarily disable SELinux enforcement until you explicitly reenable it or reboot.
+
+Next, follow the [basic installation instructions](./nbe-ec-installation.md).
+
+Finally, run the following commands to make sure your Embedded Cluster installation is accessible with enforcement enabled:
+
+```bash
+export EC_DIR="/var/lib/embedded-cluster"
+export KUBE_DIR="${EC_DIR}/k0s"
+
+# tell SELinux the Embedded Cluster directory is owned by Containerd
+sudo semanage fcontext -a -t container_var_lib_t "${EC_DIR}"
+sudo restorecon -R -v "${EC_DIR}"
+
+# additionally, binaries should be allowed to execute
+sudo semanage fcontext -a -t container_runtime_exec_t "${KUBE_DIR}/bin/containerd.*"
+sudo semanage fcontext -a -t container_runtime_exec_t "${KUBE_DIR}/bin/runc"
+sudo restorecon -R -v "${KUBE_DIR}/bin"
+
+# fix permissions for containerd and restrict some folders to read-only
+sudo semanage fcontext -a -t container_var_lib_t "${KUBE_DIR}/containerd(/.*)?"
+sudo semanage fcontext -a -t container_ro_file_t "${KUBE_DIR}/containerd/io.containerd.snapshotter.*/snapshots(/.*)?"
+sudo restorecon -R -v ${KUBE_DIR}/containerd
+```
+
+You can then reboot, or run `sudo setenforce 1` to put your system back into a normal state.

--- a/docs/netbox-enterprise/nbe-release-notes.md
+++ b/docs/netbox-enterprise/nbe-release-notes.md
@@ -1,6 +1,75 @@
 # NetBox Enterprise 1.x Release Notes
 
-## 1.4.0
+### 1.4.2
+
+A re-release of 1.4.1 with a fix that makes sure plugin versions
+that are only compatible with NetBox 4.1 are not included.
+
+#### Features
+
+* *netbox:* update to latest 4.0.x-compatible plugins (ENG-3923)
+
+#### Plugins
+
+The following plugins are included in this release:
+
+| Plugin | Version | Certified |
+| ------ | ------- | --------- |
+| nbrisk | 40.0.1 | ☐ |
+| netbox-acls | 1.6.1 | ☐ |
+| netbox-bgp | 0.13.3 | ☑︎ |
+| netbox-config-diff | 2.7.0 | ☐ |
+| netbox-documents | 0.7.0 | ☐ |
+| netbox-floorplan-plugin | 0.4.1 | ☑︎ |
+| netbox-interface-synchronization | 4.1.4 | ☐ |
+| netbox-inventory | 2.0.2 | ☐ |
+| netbox-lifecycle | 1.0.4 | ☐ |
+| netbox-plugin-dns | 1.1.5 | ☑︎ |
+| netbox-qrcode | 0.0.14 | ☑︎ |
+| netbox-reorder-rack | 1.1.3 | ☐ |
+| netbox-secrets | 2.0.3 | ☐ |
+| netbox-topology-views | 4.0.1 | ☑︎ |
+| netbox-validity | 3.0.5 | ☐ |
+| netboxlabs-diode-netbox-plugin | 0.3.0 | ☐ |
+| phonebox-plugin | 0.0.9 | ☐ |
+| slurpit_netbox | 0.9.84 | ☑︎ |
+
+### 1.4.1
+
+A small release with some dependency updates and the latest set
+of NetBox 4.0-compatible plugins.
+
+#### Features
+
+* *deps:* update bitnami-common and netbox oss charts
+* *netbox:* update to latest 4.0.x-compatible plugins (ENG-3794)
+
+#### Plugins
+
+The following plugins are included in this release:
+
+| Plugin | Version | Certified |
+| ------ | ------- | --------- |
+| nbrisk | 41.0.1 | ☐ |
+| netbox-acls | 1.7.0 | ☑︎ |
+| netbox-bgp | 0.14.0 | ☑︎ |
+| netbox-config-diff | 2.7.0 | ☐ |
+| netbox-documents | 0.7.0 | ☐ |
+| netbox-floorplan-plugin | 0.4.1 | ☑︎ |
+| netbox-interface-synchronization | 4.1.4 | ☐ |
+| netbox-inventory | 2.1.0 | ☐ |
+| netbox-lifecycle | 1.1.3 | ☐ |
+| netbox-plugin-dns | 1.1.5 | ☑︎ |
+| netbox-qrcode | 0.0.15 | ☑︎ |
+| netbox-reorder-rack | 1.1.3 | ☐ |
+| netbox-secrets | 2.1.0 | ☐ |
+| netbox-topology-views | 4.1.0 | ☑︎ |
+| netbox-validity | 3.0.5 | ☐ |
+| netboxlabs-diode-netbox-plugin | 0.6.0 | ☑︎ |
+| phonebox-plugin | 0.0.10 | ☐ |
+| slurpit_netbox | 1.0.33 | ☑︎ |
+
+### 1.4.0
 
 Adds support for supplying custom environment variables (eg, for LDAP config).
 It also contains a small auth change to allow curly braces and spaces in the new password validator.
@@ -12,49 +81,48 @@ A number of included plugins were updated to their latest compatible versions:
 * `netbox_topology_views` was updated to 4.0.1
 * `slurpit_netbox` was updated to 0.9.84
 
-
-## 1.3.0
+### 1.3.0
 
 Compatible with any standard Kubernetes ingress controller now in KOTS installs, rather than only Nginx.
 Also fixes a potential data loss issue with uploaded images, as well as enabling script and report uploads.
 
-## 1.2.0
+### 1.2.0
 
 Improves ingress configuration, adds support for inheriting the TLS configuration from the Embedded Cluster, and adds a "restore mode" for restoring manual backup data, plus many dependency updates and internal improvements.
 
-## 1.1.0
+### 1.1.0
 
 Simplifies the firewall configuration necessary for installation by making sure all initialization downloads go through our proxy domain.
 
-## 1.0.6
+### 1.0.6
 
 Adds support for NetBox resource usage adjustment and some improvements to startup time on a first install.
 
 It also adds support for backup and restore in the Embedded Cluster and KOTS installs, depending on your environment and license.
 
-## 1.0.5
+### 1.0.5
 
 Adds support for KOTS installs to scrape Prometheus metrics from NetBox, as well as the embedded PostgreSQL, Redis, and SeaweedFS if they are enabled.
 
 Updated to support NetBox v4.0.9, and includes additional bug fixes and startup time improvements.
 
-## 1.0.4
+### 1.0.4
 
 Adds OWASP password complexity validation to NetBox, and includes dependency updates.
 
-## 1.0.3
+### 1.0.3
 
 Fixes issues with preflight checks, and includes minor dependency updates.
 
-## 1.0.2
+### 1.0.2
 
 Provides a number of dependency updates and bug fixes, and includes initial support for backups of built-in Redis and PostgreSQL.
 
-## 1.0.1
+### 1.0.1
 
 Provides bug fixes encountered during the initial rollout of the NetBox Enterprise application.
 
-## 1.0.0
+### 1.0.0
 
 Provides final cleanup of the Beta stream in preparation for the wider release.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -95,9 +95,9 @@ nav:
     - Embedded Cluster:
       - Requirements: "netbox-enterprise/nbe-ec-requirements.md"
       - Installation: "netbox-enterprise/nbe-ec-installation.md"
-    - KOTS:
-      - Requirements: "netbox-enterprise/nbe-kots-requirements.md"
-      - Installation: "netbox-enterprise/nbe-kots-installation.md"
+    #- KOTS:
+    #  - Requirements: "netbox-enterprise/nbe-kots-requirements.md"
+    #  - Installation: "netbox-enterprise/nbe-kots-installation.md"
     - SSO:
       - NBE Azure Group Mapping: "netbox-enterprise/nbe-azure-group-mapping.md"
     - "Administration":


### PR DESCRIPTION
1. Remove Redis-related instructions for backup/restore, etc. (As of 1.6.4, NBE does not persist Redis.)
2. Remove references to KOTS installs, since they are now technically unsupported except in special cases.
3. Move the "advanced" stuff to requirements, so it's clear you have to do prep before installing.
4. Update the release notes to match latest Stable. (1.4.2)