### PR TITLE
ENG-3595/ENG-4375: plugin install documentation

### DIFF
--- a/docs/netbox-enterprise/nbe-ec-custom-plugins.md
+++ b/docs/netbox-enterprise/nbe-ec-custom-plugins.md
@@ -66,6 +66,8 @@ This should create a tarball that contains the `wheelhouse/` directory and every
 ## Add your plugins to NetBox Enterprise
 
 On your NetBox Enterprise node, you can now upload the wheelhouse to a media directory.
+Note that this should work whether or not you are in restore mode.
+Both are configured to be able to accept wheelhouse uploads.
 
 To do so, run this:
 
@@ -81,3 +83,10 @@ kubectl cp -n kotsadm \
   /tmp/wheelhouse.tar.gz \
   "${NBE_SOURCE_POD}:/opt/netbox/netbox/media/wheelhouse.tar.gz"
 ```
+
+## Restart the NetBox containers
+
+The next time the NetBox pods restart, they should automatically apply your changes.
+
+If you are in restore mode, switching out of restore mode will enable installation of your plugins.
+If you are not, a "redeploy" in the admin console should do the same.

--- a/docs/netbox-enterprise/nbe-ec-custom-plugins.md
+++ b/docs/netbox-enterprise/nbe-ec-custom-plugins.md
@@ -25,7 +25,7 @@ To do so, download it with this command:
 ```{.bash}
 NBE_SOURCE_POD="$( \
   kubectl get pods -A \
-  -o go-template='{{ range .items }}{{ .kind }}/{{ .metadata.name }}{{ "\n" }}{{ end }}' \
+  -o go-template='{{ range .items }}{{ .metadata.name }}{{ "\n" }}{{ end }}' \
   -l com.netboxlabs.netbox-enterprise/custom-plugins-upload=true \
   | head -n 1 \
 )"
@@ -72,7 +72,7 @@ To do so, run this:
 ```{.bash}
 NBE_SOURCE_POD="$( \
   kubectl get pods -A \
-  -o go-template='{{ range .items }}{{ .kind }}/{{ .metadata.name }}{{ "\n" }}{{ end }}' \
+  -o go-template='{{ range .items }}{{ .metadata.name }}{{ "\n" }}{{ end }}' \
   -l com.netboxlabs.netbox-enterprise/custom-plugins-upload=true \
   | head -n 1 \
 )"


### PR DESCRIPTION
Note that this documentation is not currently connected to the menu in `mkdocs.yml`, so it is safe to deploy even though NBE 1.8 is not yet released to Stable.