### PR TITLE
docs: update to detect namespace

### DIFF
--- a/docs/netbox-enterprise/nbe-backups.md
+++ b/docs/netbox-enterprise/nbe-backups.md
@@ -73,7 +73,9 @@ Runtime files are stored in a volume accessible from the NetBox containers.
 To back them up, you can run this:
 
 ```shell
-NETBOX_NAMESPACE="kotsadm" && \
+NETBOX_NAMESPACE="$(kubectl get deployments \
+  -A -l 'app.kubernetes.io/component=netbox' \
+  -ojsonpath='{.items[0].metadata.namespace}')" && \
 NETBOX_MAIN_POD="$(kubectl get pod \
   -o name \
   -n "${NETBOX_NAMESPACE}" \
@@ -101,7 +103,9 @@ Since the PostgreSQL CLI tools are already available inside the cluster, all we 
 To perform a database dump, run these commands:
 
 ```shell
-NETBOX_NAMESPACE="kotsadm" && \
+NETBOX_NAMESPACE="$(kubectl get deployments \
+  -A -l 'app.kubernetes.io/component=netbox' \
+  -ojsonpath='{.items[0].metadata.namespace}')" && \
 NETBOX_DATABASE_FILE="netbox-enterprise.pgsql" && \
 POSTGRESQL_MAIN_POD="$(kubectl get pod \
   -o name \
@@ -141,7 +145,9 @@ To ensure that Diode OAuth login information is not lost, you will also need to 
 Run this set of commands:
 
 ```shell
-NETBOX_NAMESPACE="kotsadm" && \
+NETBOX_NAMESPACE="$(kubectl get deployments \
+  -A -l 'app.kubernetes.io/component=netbox' \
+  -ojsonpath='{.items[0].metadata.namespace}')" && \
 (
   kubectl get secrets \
     --namespace "${NETBOX_NAMESPACE}" \
@@ -189,7 +195,9 @@ To restore media, scripts, and reports, you just need to unpack them into the co
     If you are restoring a backup from another NetBox instance, you might need to change the name of the tarball and the path after the `-C` at the end of this command to unpack your backup into the right location.
 
 ```shell
-NETBOX_NAMESPACE="kotsadm" && \
+NETBOX_NAMESPACE="$(kubectl get deployments \
+  -A -l 'app.kubernetes.io/component=netbox' \
+  -ojsonpath='{.items[0].metadata.namespace}')" && \
 NETBOX_RESTORE_POD="$(kubectl get pod \
   -o name \
   -n "${NETBOX_NAMESPACE}" \
@@ -211,7 +219,9 @@ To restore from a secrets yaml file, pass it to `kubectl apply` like so:
 
 ```shell
 # add/replace existing diode secrets
-NETBOX_NAMESPACE="kotsadm" && \
+NETBOX_NAMESPACE="$(kubectl get deployments \
+  -A -l 'app.kubernetes.io/component=netbox' \
+  -ojsonpath='{.items[0].metadata.namespace}')" && \
 kubectl apply \
   --server-side \
   --force-conflicts \
@@ -224,7 +234,9 @@ kubectl apply \
 To restore from a dump file, pipe the `netbox-enterprise.pgsql` created during backup into `psql` in the PostgreSQL pod:
 
 ```shell
-NETBOX_NAMESPACE="kotsadm" && \
+NETBOX_NAMESPACE="$(kubectl get deployments \
+  -A -l 'app.kubernetes.io/component=netbox' \
+  -ojsonpath='{.items[0].metadata.namespace}')" && \
 NETBOX_DATABASE_FILE="netbox-enterprise.pgsql" && \
 DIODE_DEPLOYMENT_COUNT="$(kubectl get deployments -n "${NETBOX_NAMESPACE}" -o name | grep -c diode || :)" && \
 HYDRA_DEPLOYMENT_COUNT="$(kubectl get deployments -n "${NETBOX_NAMESPACE}" -o name | grep -c hydra || :)" && \
@@ -265,7 +277,9 @@ done && \
 Following this run the below to ensure all database permissions are correct:
 
 ```shell
-NETBOX_NAMESPACE="kotsadm" && \
+NETBOX_NAMESPACE="$(kubectl get deployments \
+  -A -l 'app.kubernetes.io/component=netbox' \
+  -ojsonpath='{.items[0].metadata.namespace}')" && \
 POSTGRESQL_MAIN_POD="$(kubectl get pod \
   -o name \
   -n "${NETBOX_NAMESPACE}" \

--- a/docs/netbox-enterprise/nbe-ec-custom-plugins.md
+++ b/docs/netbox-enterprise/nbe-ec-custom-plugins.md
@@ -31,8 +31,12 @@ NBE_SOURCE_POD="$( \
   --field-selector status.phase=Running \
   | head -n 1 \
 )"
+NETBOX_NAMESPACE="$(kubectl get deployments \
+  -A -l 'app.kubernetes.io/component=netbox' \
+  -ojsonpath='{.items[0].metadata.namespace}')"
 
-kubectl cp -n kotsadm \
+kubectl cp \
+  --namespace "${NETBOX_NAMESPACE}" \
   "${NBE_SOURCE_POD}:/opt/netbox/constraints.txt" \
   /tmp/wheelhouse/constraints.txt
 ```
@@ -109,8 +113,12 @@ NBE_SOURCE_POD="$( \
   --field-selector status.phase=Running \
   | head -n 1 \
 )"
+NETBOX_NAMESPACE="$(kubectl get deployments \
+  -A -l 'app.kubernetes.io/component=netbox' \
+  -ojsonpath='{.items[0].metadata.namespace}')"
 
-kubectl cp -n kotsadm \
+kubectl cp \
+  --namespace "${NETBOX_NAMESPACE}" \
   /tmp/wheelhouse.tar.gz \
   "${NBE_SOURCE_POD}:/opt/netbox/netbox/media/wheelhouse.tar.gz"
 ```


### PR DESCRIPTION
This pull request updates the backup and restore documentation for NetBox Enterprise to dynamically determine the namespace of the NetBox deployment, replacing the hardcoded `kotsadm` namespace with a command that retrieves it automatically. This change improves flexibility and reduces the likelihood of errors in environments with custom namespaces.

### Documentation Improvements:
* Updated all instances of `NETBOX_NAMESPACE="kotsadm"` to dynamically retrieve the namespace of the NetBox deployment using the `kubectl get deployments` command with appropriate labels and JSONPath output. This ensures compatibility with custom namespaces. [[1]](diffhunk://#diff-18aeb726b704282fe5d289a76aa42fdbc6ee6558b110b73ffcb9540e9b9377bcL76-R78) [[2]](diffhunk://#diff-18aeb726b704282fe5d289a76aa42fdbc6ee6558b110b73ffcb9540e9b9377bcL104-R108) [[3]](diffhunk://#diff-18aeb726b704282fe5d289a76aa42fdbc6ee6558b110b73ffcb9540e9b9377bcL144-R150) [[4]](diffhunk://#diff-18aeb726b704282fe5d289a76aa42fdbc6ee6558b110b73ffcb9540e9b9377bcL192-R200) [[5]](diffhunk://#diff-18aeb726b704282fe5d289a76aa42fdbc6ee6558b110b73ffcb9540e9b9377bcL214-R224) [[6]](diffhunk://#diff-18aeb726b704282fe5d289a76aa42fdbc6ee6558b110b73ffcb9540e9b9377bcL227-R239) [[7]](diffhunk://#diff-18aeb726b704282fe5d289a76aa42fdbc6ee6558b110b73ffcb9540e9b9377bcL268-R282)