### PR TITLE
docs: remove permissions/owner dump flags, simplify DB creation

### DIFF
--- a/docs/netbox-enterprise/nbe-backups.md
+++ b/docs/netbox-enterprise/nbe-backups.md
@@ -258,7 +258,7 @@ done && \
   fi && \
   echo "CREATE DATABASE netbox WITH TEMPLATE = template0 ENCODING = 'UTF8';" && \
   echo "" && \
-  echo ""; \
+  echo "" && \
   grep -v -E '^CREATE DATABASE ' "${NETBOX_DATABASE_FILE}"; \
 ) \
 | kubectl exec "${POSTGRESQL_MAIN_POD}" \

--- a/docs/netbox-enterprise/nbe-backups.md
+++ b/docs/netbox-enterprise/nbe-backups.md
@@ -259,7 +259,7 @@ done && \
   echo "CREATE DATABASE netbox WITH TEMPLATE = template0 ENCODING = 'UTF8';" && \
   echo "" && \
   echo "" && \
-  grep -v -E '^CREATE DATABASE ' "${NETBOX_DATABASE_FILE}"; \
+  grep -v -E '^(ALTER|CREATE|DROP) (DATABASE|ROLE) ' "${NETBOX_DATABASE_FILE}" \
 ) \
 | kubectl exec "${POSTGRESQL_MAIN_POD}" \
   -n "${NETBOX_NAMESPACE}" \

--- a/docs/netbox-enterprise/nbe-backups.md
+++ b/docs/netbox-enterprise/nbe-backups.md
@@ -126,9 +126,6 @@ kubectl exec "${POSTGRESQL_MAIN_POD}" \
   -c database \
   -- \
     pg_dumpall \
-      --no-role-passwords \
-      --no-privileges \
-      --no-owner \
       $EXCLUDE_DATABASES \
     > "${NETBOX_DATABASE_FILE}"
 ```
@@ -253,19 +250,16 @@ for DB in netbox diode hydra; do
     -- dropdb --if-exists --force "${DB}"; \
 done && \
 ( \
-  if ! grep --quiet -E '^CREATE DATABASE ' "${NETBOX_DATABASE_FILE}"; then \
-    if [ "${DIODE_DEPLOYMENT_COUNT}" -gt 0 ]; then \
-      echo "CREATE DATABASE diode WITH TEMPLATE = template0 ENCODING = 'UTF8';"; \
-    fi && \
-    if [ "${HYDRA_DEPLOYMENT_COUNT}" -gt 0 ]; then \
-      echo "CREATE DATABASE hydra WITH TEMPLATE = template0 ENCODING = 'UTF8';"; \
-    fi && \
-    echo "CREATE DATABASE netbox WITH TEMPLATE = template0 ENCODING = 'UTF8';" && \
-    echo "" && \
-    echo "\\connect netbox" && \
-    echo ""
+  if [ "${DIODE_DEPLOYMENT_COUNT}" -gt 0 ]; then \
+    echo "CREATE DATABASE diode WITH TEMPLATE = template0 ENCODING = 'UTF8';"; \
   fi && \
-  cat "${NETBOX_DATABASE_FILE}" \
+  if [ "${HYDRA_DEPLOYMENT_COUNT}" -gt 0 ]; then \
+    echo "CREATE DATABASE hydra WITH TEMPLATE = template0 ENCODING = 'UTF8';"; \
+  fi && \
+  echo "CREATE DATABASE netbox WITH TEMPLATE = template0 ENCODING = 'UTF8';" && \
+  echo "" && \
+  echo ""; \
+  cat "${NETBOX_DATABASE_FILE}" | grep -v -E '^CREATE DATABASE '; \
 ) \
 | kubectl exec "${POSTGRESQL_MAIN_POD}" \
   -n "${NETBOX_NAMESPACE}" \

--- a/docs/netbox-enterprise/nbe-backups.md
+++ b/docs/netbox-enterprise/nbe-backups.md
@@ -259,7 +259,7 @@ done && \
   echo "CREATE DATABASE netbox WITH TEMPLATE = template0 ENCODING = 'UTF8';" && \
   echo "" && \
   echo ""; \
-  cat "${NETBOX_DATABASE_FILE}" | grep -v -E '^CREATE DATABASE '; \
+  grep -v -E '^CREATE DATABASE ' "${NETBOX_DATABASE_FILE}"; \
 ) \
 | kubectl exec "${POSTGRESQL_MAIN_POD}" \
   -n "${NETBOX_NAMESPACE}" \


### PR DESCRIPTION
This pull request updates the backup and restore process for NetBox databases in the `docs/netbox-enterprise/nbe-backups.md` file. The changes focus on removing unnecessary database attributes during export and ensuring cleaner imports by filtering out specific SQL statements.

### Updates to database export and import processes:

* **Export process simplification**:
  - Removed options from the `pg_dumpall` command that excluded roles, privileges, and ownership during database export. (`[docs/netbox-enterprise/nbe-backups.mdL129-L131](diffhunk://#diff-18aeb726b704282fe5d289a76aa42fdbc6ee6558b110b73ffcb9540e9b9377bcL129-L131)`)

* **Import process refinement**:
  - Removed the check for `CREATE DATABASE` statements in the backup file and added a filter to exclude `ALTER`, `CREATE`, and `DROP` statements for `DATABASE` and `ROLE` during import. (`[docs/netbox-enterprise/nbe-backups.mdL265-R262](diffhunk://#diff-18aeb726b704282fe5d289a76aa42fdbc6ee6558b110b73ffcb9540e9b9377bcL265-R262)`)

### Code cleanup:

* **Removed redundant logic**:
  - Eliminated unnecessary conditional checks related to database creation during the restore process. (`[docs/netbox-enterprise/nbe-backups.mdL256](diffhunk://#diff-18aeb726b704282fe5d289a76aa42fdbc6ee6558b110b73ffcb9540e9b9377bcL256)`)