### PR TITLE
Restore documentation and scripts removed in PR154

### DIFF
--- a/docs/netbox-extensions/changes/changelog.md
+++ b/docs/netbox-extensions/changes/changelog.md
@@ -1,0 +1,5 @@
+# Change Log
+
+## v0.2.0
+
+* Initial release

--- a/docs/netbox-extensions/changes/configuration.md
+++ b/docs/netbox-extensions/changes/configuration.md
@@ -1,0 +1,9 @@
+# Configuration Parameters
+
+The following plugin configuration parameters are available.
+
+## `protect_main`
+
+Default: False
+
+When enabled, all object creations, changes, and deletions must be made within a branch. Changes to objects in main will not be permitted, except for those object types which do not support branching.

--- a/docs/netbox-extensions/changes/index.md
+++ b/docs/netbox-extensions/changes/index.md
@@ -1,0 +1,38 @@
+# NetBox Change Management
+
+This plugin adds change management support to [NetBox](http://netboxlabs.com/oss/netbox/). Leveraging the [netbox-branching](https://github.com/netboxlabs/netbox-branching) plugin, it implements policy and workflow controls to ensure proposed changes undergo formal review prior to being merged. It also retains a written record of all approved changes.
+
+## Getting Started
+
+### Defining a Policy
+
+Change policies determine who is eligible to approve a change request and how many approvals a change request requires. Each policy contains one or more rules which define these parameters.
+
+Begin by creating a new policy with a name of your choosing, then add however many rules are necessary to enforce your organization's change policy.
+
+For example, suppose your team requires that every change be approved by two engineers (members of the Engineering group in NetBox) and one of the two lead engineers (Alice and Bob). This can be achieved by adding two rules to the policy.
+
+| Rule | Minimum reviews | Reviewer groups | Reviewers  |
+|------|-----------------|-----------------|------------|
+| #1   | 2               | Engineering     | -          |
+| #2   | 1               | -               | Alice, Bob |
+
+This policy will be met only when at least two members of the Engineering group _and_ Alice or Bob submit approvals.
+
+### Create a Change Request
+
+When you've finished staging your changes in a branch, click the "request review" button at the top of the branch view. This will take you to the change request creation form.
+
+Enter a name for your change request (or keep the default value, taken from the branch's name) and select the change policy which applies to your request. Each change request will be opened in "draft" status with medium priority by default, but these can be changed. Go ahead and change the status to "needs review" if it's ready for review now. Finally, provide a brief summary of your changes for reviewers.
+
+### Reviewing a Change Request
+
+Once a change request has been submitted, it can be reviewed by other users. To review a change request, click the "add a review" link above the list of reviews (if any). Select the status of your review and provide any comments you have. Your review will now show up under the change request.
+
+Alternatively, if you'd like to provide more detailed feedback, select the "changes" tab. Here, you can comment on specific changes within the branch and cite any concerns or suggestions you have. Other users can then reply to your comments.
+
+### Applying a Change Request
+
+Once a change request has been approved, the "merge" button will appear. Clicking it will take you to the form to merge the corresponding branch.
+
+Once the branch has been merged successfully, the change request's status will be automatically updated to "completed."

--- a/docs/netbox-extensions/changes/models/changerequest.md
+++ b/docs/netbox-extensions/changes/models/changerequest.md
@@ -1,0 +1,50 @@
+# Change Requests
+
+A change request is submitted to request approval of proposed changes in a branch before it can be merged. All rules of the assigned [change policy](./policy.md) must be met for the request to be approved. When submitting a change request for a branch, the owner selects the governing policy and designates a priority.
+
+## Fields
+
+### Name
+
+The user-defined name of the change request.
+
+### Owner
+
+The user who submitted the change request.
+
+### Policy
+
+The [policy](./policy.md) which must be met for the change request to be approved.
+
+!!! note
+    The policy is selected by the change request owner.
+
+### Branch
+
+The branch which will be merged when the change request has been approved.
+
+### Status
+
+The current status of the change request. Valid statuses are listed below.
+
+| Status       | Description                                        |
+|--------------|----------------------------------------------------|
+| Draft        | Not yet ready for review                           |
+| Needs review | Waiting for reviews to satisfy the assigned policy |
+| Approved     | The assigned policy has been met                   |
+| Completed    | The assigned branch has been merged                |
+| Rejected     | The proposed changes have been rejected            |
+
+### Priority
+
+The priority of the change request relative to other open requests. Valid priorities are listed below.
+
+* High (5)
+* Medium/high (4)
+* Medium (3)
+* Medium/low (2)
+* Low (1)
+
+### Summary
+
+A short summary of the proposed changes, reasoning for why they are being made, and any other relevant notes for reviewers.

--- a/docs/netbox-extensions/changes/models/comment.md
+++ b/docs/netbox-extensions/changes/models/comment.md
@@ -1,0 +1,25 @@
+# Comments
+
+As part of the review process, users can leave comments on [change requests](./changerequest.md) to ask question or suggest changes. Each comment may start a thread of [replies](./commentreply.md) and can be marked resolved, which will hide the reply thread.
+
+## Fields
+
+### Author
+
+The user who created the comment.
+
+### Change Request
+
+The [change request](./changerequest.md) to which the comment applies.
+
+### Change Diff
+
+The specific change within the change request the comment applies (optional).
+
+### Content
+
+The comment body.
+
+### Resolved
+
+A boolean attribute indicating whether the comment has been addressed by the change request owner.

--- a/docs/netbox-extensions/changes/models/commentreply.md
+++ b/docs/netbox-extensions/changes/models/commentreply.md
@@ -1,0 +1,17 @@
+# Comment Replies
+
+Each [comment](./comment.md) on a [change request](./changerequest.md) starts a new discussion thread to which users can reply. This helps keep the discussion around a change request organized.
+
+## Fields
+
+### Author
+
+The user who created the reply.
+
+### Comment
+
+The comment to which the reply thread belongs.
+
+### Content
+
+The reply body.

--- a/docs/netbox-extensions/changes/models/policy.md
+++ b/docs/netbox-extensions/changes/models/policy.md
@@ -1,0 +1,12 @@
+# Policies
+
+A policy defines the conditions that must be met for a [change request](./changerequest.md) to be merged. Each policy defines one or more [rules](./policyrule.md) which assert these conditions. All rules must be met for the policy to be satisfied.
+
+!!! note
+    A policy with no rules defined will always fail.
+
+## Fields
+
+### Name
+
+The name by which the policy is referenced.

--- a/docs/netbox-extensions/changes/models/policyrule.md
+++ b/docs/netbox-extensions/changes/models/policyrule.md
@@ -1,0 +1,30 @@
+# Policy Rules
+
+Each [policy](./policy.md) contains one or more rules which assert certain conditions that must be met for the policy to be met. For example, you might define a policy that requires the approval of two engineers and one manager.
+
+Users whose reviews will satisfy the rule are identified by assigning individual users and/or groups of users for each rule. The minimum reviews parameter defines how many approved must be submitted for the rule to be met.
+
+## Fields
+
+### Name
+
+The short name by which the rule is identified.
+
+### Enabled
+
+A boolean indicating whether the rule is enabled. Rules are enabled by default.
+
+### Minimum Reviews
+
+The minimum number of eligible reviewers which must approve the change in order for the rule to pass.
+
+!!! note
+    A value of zero may be set to assert that a rule shall always pass, although this is generally not recommended.
+
+### Reviewer Groups
+
+Groups of users whose approval will satisfy this rule.
+
+### Reviewers
+
+Individual users whose approval will satisfy this rule.

--- a/docs/netbox-extensions/changes/models/review.md
+++ b/docs/netbox-extensions/changes/models/review.md
@@ -1,0 +1,25 @@
+# Reviews
+
+Reviews are submitted to approve, reject, or comment on a [change request](./changerequest.md). The users eligible to review a particular change request are determined by its assigned [change policy](./policy.md).
+
+## Fields
+
+### Change Request
+
+The [change request](./changerequest.md) being reviewed.
+
+### User
+
+The author of the review.
+
+### Status
+
+The current status of the review. Valid statuses are listed below.
+
+| Status            | Description                                                      |
+|-------------------|------------------------------------------------------------------|
+| Pending           | The review is in progress                                        |
+| Comment           | The reviewer has questions or feedback                           |
+| Changes Requested | The reviewer has requested modifications to the proposed changes |
+| Approved          | The proposed changes are accepted                                |
+| Rejected          | The proposed changes are rejected                                |

--- a/docs/netbox-extensions/diode/diode-get-started.md
+++ b/docs/netbox-extensions/diode/diode-get-started.md
@@ -1,0 +1,246 @@
+# Get Started with Diode
+
+This guide will help you set up and start using Diode to ingest data into NetBox.
+
+## Prerequisites
+
+Before you begin, ensure you have:
+
+- NetBox version 4.2.3 or later
+- Docker version 27.0.3 or newer
+- bash 4.x or newer
+- jq
+- Network connectivity between your NetBox server and the Diode server
+- Sufficient permissions to run Docker commands
+
+## Installation Steps
+
+### Deploy Diode server
+
+> **Host**: These steps should be performed on the host where you want to run the Diode server.
+
+> **Note**: For the complete installation instructions, please refer to the [official Diode Server documentation](https://github.com/netboxlabs/diode/tree/develop/diode-server).
+
+We provide a `quickstart.sh` script to automate the setup process. The script will download and configure all necessary files:
+
+- `docker-compose.yaml` — Defines Diode server containers
+- `.env` — Environment settings for customization
+- `nginx.conf` — Nginx configuration for routing Diode endpoints
+- `client-credentials.json` — Defines OAuth2 clients for secure communication
+
+1. Create a working directory:
+   ```bash
+   mkdir -p /opt/diode
+   cd /opt/diode
+   ```
+
+2. Download and prepare the quickstart script:
+   ```bash
+   curl -sSfLo quickstart.sh https://raw.githubusercontent.com/netboxlabs/diode/release/diode-server/docker/scripts/quickstart.sh
+   chmod +x quickstart.sh
+   ```
+
+3. Run the script with your NetBox server address:
+   ```bash
+   ./quickstart.sh https://<netbox-server>
+   ```
+   > **Note**: Replace `<netbox-server>` with your actual NetBox server address. Do not include a trailing slash.
+   > Example: `./quickstart.sh https://netbox.example.com`
+
+   This should have created an `.env` file for your environment.
+
+4. Start the Diode server:
+   ```bash
+   docker compose up -d
+   ```
+
+5. Verify the Diode server is running:
+   ```bash
+   docker compose ps
+   ```
+   All services should show as "running" or "healthy".
+
+6. Extract the `netbox-to-diode` client secret. This will be needed for the Diode NetBox plugin installation:
+   ```bash
+   echo $(jq -r '.[] | select(.client_id == "netbox-to-diode") | .client_secret' /opt/diode/oauth2/client/client-credentials.json)
+   ```
+   > **Note**: This will return a credential that will be used by the Diode NetBox plugin to connect to the Diode server. Store it safely.
+
+### Install Diode NetBox Plugin
+
+> **Host**: These steps should be performed on the host where NetBox is installed.
+
+> **Note**: For the complete installation instructions, please refer to the [official Diode NetBox Plugin documentation](https://github.com/netboxlabs/diode-netbox-plugin/blob/develop/README.md).
+
+1. **Source the NetBox Python Virtual Environment**
+   ```bash
+   cd /opt/netbox
+   source venv/bin/activate
+   ```
+
+2. **Install the Plugin Package**
+   ```bash
+   pip install netboxlabs-diode-netbox-plugin
+   ```
+
+3. **Configure NetBox Settings**
+   Add the following to your `configuration.py`:
+   ```python
+   PLUGINS = [
+       "netbox_diode_plugin",
+   ]
+
+   PLUGINS_CONFIG = {
+       "netbox_diode_plugin": {
+           # Diode gRPC target for communication with Diode server
+           "diode_target_override": "grpc://<diode-server:port>/diode",
+           # NetBox username associated with changes applied via plugin
+           "diode_username": "diode",
+           # netbox-to-diode client secret from earlier step
+           "netbox_to_diode_client_secret": "<netbox-to-diode-secret>"
+       },
+   }
+   ```
+   > **Note**: Replace `<diode-server:port>` with your Diode server address and port (default: 8080)
+   > Example: `grpc://diode.example.com:8080/diode`
+
+4. **Apply Database Migrations**
+   ```bash
+   cd /opt/netbox/netbox
+   ./manage.py migrate netbox_diode_plugin
+   ```
+
+5. **Restart NetBox Services**
+   ```bash
+   sudo systemctl restart netbox netbox-rq
+   ```
+
+6. **Generate Diode Client Credentials**
+   > **Note**: These credentials will be used by the Orb agent to send discovery results to NetBox via Diode.
+
+   1. Go to your NetBox instance (https://<netbox-server>)
+   2. In the left-hand pane, navigate to **Diode -> Client Credentials**
+   3. Click on **+ Add a Credential**
+   4. For Client Name, enter any name and click **Create**
+   5. **IMPORTANT**: Copy the _Client ID_ and _Client Secret_ and save them securely
+   6. Click **Return to List**
+
+   You have now created your Diode client credentials. These will be used as environment variables when running the Orb agent.
+
+### Ingest Data with Orb Agent
+
+> **Host**: These steps should be performed on the host where you want to run the Orb agent for network discovery.
+
+> **Note**: For the complete installation instructions, please refer to the [official Orb Agent documentation](https://github.com/netboxlabs/orb-agent).
+
+1. **Export Client Credentials**
+   ```bash
+   # Export the client credentials you generated in NetBox
+   export DIODE_CLIENT_ID="<your-client-id>"
+   export DIODE_CLIENT_SECRET="<your-client-secret>"
+   ```
+
+2. **Create Agent Configuration File**
+   Create an `agent.yaml` file with the following content:
+   ```yaml
+   orb:
+     config_manager:
+       active: local
+     backends:
+       network_discovery:  # Enable network discovery backend
+       common:
+         diode:
+           target: grpc://<diode-server:port>/diode
+           client_id: ${DIODE_CLIENT_ID}
+           client_secret: ${DIODE_CLIENT_SECRET}
+           agent_name: my_agent
+     policies:
+       network_discovery:
+         loopback_policy:
+           config:
+           scope:
+             targets: 
+               - 127.0.0.1
+   ```
+   > **Note**: Replace `<diode-server:port>` with your Diode server address and port (default: 8080)
+   > Example: `grpc://diode.example.com:8080/diode`
+
+3. **Run the Agent**
+   
+   Using host network mode (recommended):
+   ```bash
+   docker run --net=host \
+     -v $(pwd):/opt/orb/ \
+     -e DIODE_CLIENT_ID \
+     -e DIODE_CLIENT_SECRET \
+     netboxlabs/orb-agent:latest run -c /opt/orb/agent.yaml
+   ```
+
+   Alternative using root user:
+   ```bash
+   docker run -u root \
+     -v $(pwd):/opt/orb/ \
+     -e DIODE_CLIENT_ID \
+     -e DIODE_CLIENT_SECRET \
+     netboxlabs/orb-agent:latest run -c /opt/orb/agent.yaml
+   ```
+
+   > **Note**: The container needs sufficient permissions to send ICMP and TCP packets. This can be achieved either by:
+   > - Setting the network mode to `host` (recommended)
+   > - Running the container as root user
+
+4. **Verify Agent Operation**
+   - Check the agent logs for successful startup
+   - Verify data appears in NetBox
+
+## Troubleshooting
+
+### Common Issues
+
+1. **Connection Issues**
+   - Verify network connectivity between Diode and NetBox:
+     ```bash
+     # From Diode server
+     curl -v https://<netbox-server>
+     # From NetBox server
+     curl -v grpc://<diode-server:port>/diode
+     ```
+   - Check firewall rules:
+     ```bash
+     # Check if required ports are open
+     netstat -tulpn | grep -E '8080|443'
+     ```
+   - Validate URLs and ports in configuration files:
+     - Diode server `.env`
+     - NetBox `configuration.py`
+     - Orb agent `agent.yaml`
+
+2. **Docker Issues**
+   - Check Docker service status:
+     ```bash
+     systemctl status docker
+     ```
+   - Verify Docker container logs:
+     ```bash
+     docker compose logs
+     ```
+
+3. **Permission Issues**
+   - Ensure proper file permissions:
+     ```bash
+     ls -la /opt/diode/
+     ls -la /opt/netbox/
+     ```
+   - Check Docker socket permissions:
+     ```bash
+     ls -l /var/run/docker.sock
+     ```
+
+### Getting Help
+
+If you encounter issues:
+
+1. Search GitHub: [Issues](https://github.com/netboxlabs/diode/issues)
+2. Find us in Slack: [NetDev Community #orb](https://netdev-community.slack.com/)
+3. Check the logs:
+   - Diode server logs: `docker compose logs`

--- a/docs/netbox-extensions/diode/index.md
+++ b/docs/netbox-extensions/diode/index.md
@@ -1,0 +1,46 @@
+# Diode
+
+!!! info "Currently in Public Preview"
+
+    The Diode project is currently in _Public Preview_. Please see [NetBox Labs Product and Feature Lifecycle](https://netboxlabs.com/docs/product_feature_lifecycle/) for more details.
+
+## Overview 
+
+Diode is a NetBox data ingestion service that aims to simplify and enhance the process to add and update network data in NetBox. The guiding principle behind Diode has been to make it as easy as possible to get data into NetBox, removing as much burden as possible from the user while shifting that effort to technology.
+
+Diode is a sidecar service to NetBox that provides a gRPC/protobuf API designed for ingestion of common NetBox data models. Diode reduces the need to preprocess data to make it conform to the strict object hierarchy of the NetBox data model. This allows data to be sent to NetBox in a more freeform manner, in blocks that are intuitive for network engineers such as by device or by interface. Related information is treated as attributes of these blocks. Diode takes care of transforming this data to make it align with NetBox's structured and comprehensive data model.
+
+## Prerequisites
+
+* NetBox 4.2.3 or later
+* Python 3.8 or later (for Python SDK)
+* Go 1.18 or later (for Go SDK)
+* Network connectivity between Diode and NetBox
+
+## Components
+
+There are several components that make up the Diode ecosystem:
+
+1. **Diode Server** - The core service that provides ingestion and reconciliation services. See [deployment instructions](https://github.com/netboxlabs/diode/tree/develop/diode-server#readme).
+
+2. **Diode NetBox Plugin** - Required component that provides API key management and ORM integration into NetBox. See [installation instructions](https://github.com/netboxlabs/diode-netbox-plugin).
+
+3. **Data Ingestion Methods**:
+   * **NetBox Discovery Agent** - Automated discovery using the [Orb agent](https://github.com/netboxlabs/orb-agent).
+   * **SDK Integrations**:
+     * [Python SDK](https://github.com/netboxlabs/diode-sdk-python)
+     * [Go SDK](https://github.com/netboxlabs/diode-sdk-go)
+
+## Quick Start
+
+For a quick step-by-step guide, see our [Getting Started Guide](diode-get-started.md).
+
+## Additional Resources
+
+* [Diode Protocol Documentation](https://github.com/netboxlabs/diode/tree/develop/diode-proto)
+* Example scripts and tutorials can be found in the NetBox Labs [NetBox Learning repository](https://github.com/netboxlabs/netbox-learning/tree/develop/diode)
+
+## Support
+
+* [GitHub Issues](https://github.com/netboxlabs/diode/issues)
+* Slack NetDev Community (#orb channel)

--- a/docs/sdks/pynetbox.md
+++ b/docs/sdks/pynetbox.md
@@ -1,0 +1,55 @@
+# NetBox SDKs
+
+!!! info "Documentation Location"
+    **NetBox SDK documentation has moved!**
+    
+    For the most current and authoritative NetBox SDK documentation, please visit:
+    
+    **[NetBox SDKs Documentation →](https://netboxlabs.com/docs/netbox-sdks/)**
+
+## About NetBox SDKs
+
+NetBox SDKs provide programmatic access to NetBox through various programming languages. These libraries simplify integration with NetBox's REST API and enable automation of network infrastructure management tasks.
+
+### Available SDKs
+
+- **[pynetbox](https://netboxlabs.com/docs/netbox-sdks/pynetbox/)** - Python API client library
+- **[netbox-python](https://netboxlabs.com/docs/netbox-sdks/netbox-python/)** - Alternative lightweight Python wrapper
+- **[go-netbox](https://netboxlabs.com/docs/netbox-sdks/go-netbox/)** - Go client library
+- **[netbox-client-ruby](https://netboxlabs.com/docs/netbox-sdks/ruby/)** - Ruby client library
+
+### Key Features
+
+- **Full API Coverage**: Complete access to NetBox's REST API endpoints
+- **Authentication Support**: Token-based authentication for secure access
+- **Query Methods**: Comprehensive filtering, searching, and pagination support
+- **CRUD Operations**: Create, read, update, and delete NetBox objects
+- **Threading Support**: Multi-threaded operations for improved performance
+- **Type Safety**: Strongly typed interfaces where applicable
+
+### Getting Started
+
+To get started with NetBox SDKs, including installation instructions, authentication setup, and usage examples, please visit the official documentation:
+
+**[→ Visit NetBox SDKs Documentation](https://netboxlabs.com/docs/netbox-sdks/)**
+
+### Quick Links
+
+- **[Installation Guides](https://netboxlabs.com/docs/netbox-sdks/installation/)**
+- **[Authentication Setup](https://netboxlabs.com/docs/netbox-sdks/authentication/)**
+- **[Usage Examples](https://netboxlabs.com/docs/netbox-sdks/examples/)**
+- **[API Reference](https://netboxlabs.com/docs/netbox-sdks/api-reference/)**
+- **[Best Practices](https://netboxlabs.com/docs/netbox-sdks/best-practices/)**
+
+### Popular Use Cases
+
+- **Infrastructure Automation**: Automate device provisioning and configuration management
+- **Data Migration**: Bulk import/export of network infrastructure data
+- **Reporting & Analytics**: Generate custom reports and dashboards
+- **Integration**: Connect NetBox with other network management tools
+- **CI/CD Pipelines**: Integrate network documentation into deployment workflows
+
+---
+
+!!! note "Why the redirect?"
+    NetBox SDK documentation is maintained in its own dedicated repository to ensure you always have access to the most up-to-date information, including the latest features, compatibility updates, and best practices for each supported programming language.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -63,6 +63,17 @@ nav:
   - Community:
     - NetBox Plugins:
       - Branching: "netbox-extensions/branching/index.md"
+      - Change Management:
+        - Overview: "netbox-extensions/changes/index.md"
+        - Configuration: "netbox-extensions/changes/configuration.md"
+        - Models:
+          - Change Request: "netbox-extensions/changes/models/changerequest.md"
+          - Comment: "netbox-extensions/changes/models/comment.md"
+          - Comment Reply: "netbox-extensions/changes/models/commentreply.md"
+          - Policy: "netbox-extensions/changes/models/policy.md"
+          - Policy Rule: "netbox-extensions/changes/models/policyrule.md"
+          - Review: "netbox-extensions/changes/models/review.md"
+        - Changelog: "netbox-extensions/changes/changelog.md"
       - Diode:
         - Overview: "netbox-extensions/diode/index.md"
         - Get Started: "netbox-extensions/diode/diode-get-started.md"

--- a/scripts/update-changes-docs.sh
+++ b/scripts/update-changes-docs.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# Update NetBox Changes documentation from source repository
+# Usage: ./scripts/update-changes-docs.sh
+
+set -e
+
+REPO_URL="https://github.com/netboxlabs/netbox-changes.git"
+TARGET_DIR="docs/netbox-extensions/changes"
+TEMP_DIR="/tmp/netbox-changes-update"
+
+echo "🔄 Updating NetBox Changes documentation..."
+
+# Clean up any existing temp directory
+rm -rf "$TEMP_DIR"
+
+# Clone the source repository
+echo "📥 Cloning source repository..."
+git clone "$REPO_URL" "$TEMP_DIR"
+
+# Remove existing documentation
+echo "🗑️  Removing existing documentation..."
+rm -rf "$TARGET_DIR"/*
+
+# Copy only the docs content
+echo "📋 Copying documentation content..."
+mkdir -p "$TARGET_DIR"
+cp -r "$TEMP_DIR/docs/"* "$TARGET_DIR/"
+
+# Clean up temp directory
+echo "🧹 Cleaning up..."
+rm -rf "$TEMP_DIR"
+
+echo "✅ NetBox Changes documentation updated successfully!"
+echo ""
+echo "Next steps:"
+echo "1. Review the changes: git diff"
+echo "2. Test the build: python -m mkdocs build"
+echo "3. Commit the updates: git add $TARGET_DIR && git commit -m 'Update NetBox Changes documentation'"
+echo "4. Push the changes: git push"


### PR DESCRIPTION
## Summary
- Restores the update-changes-docs.sh script under /scripts
- Restores Change Management section in mkdocs.yml navigation
- Restores all files under /docs/netbox-extensions including changes/ and diode/ directories  
- Restores /docs/sdks/pynetbox.md file

## Context
These files were removed in PR154 as part of the dochub integration cleanup, but they should be restored to maintain documentation completeness.

## Files Restored
- `scripts/update-changes-docs.sh` - Script for updating NetBox Changes documentation
- `mkdocs.yml` - Added back Change Management navigation section
- `docs/netbox-extensions/changes/` - Complete Change Management plugin documentation
- `docs/netbox-extensions/diode/` - Diode setup and usage guides
- `docs/sdks/pynetbox.md` - NetBox SDK documentation

## Test plan
- [ ] Verify mkdocs build works correctly
- [ ] Confirm all navigation links work
- [ ] Check that restored documentation renders properly